### PR TITLE
Fix for prefetch with coded generic relation

### DIFF
--- a/src/unicef_djangolib/fields.py
+++ b/src/unicef_djangolib/fields.py
@@ -61,6 +61,13 @@ def coded_create_reverse_many_to_one_manager(superclass, rel):
             if rel.field.code:
                 self.core_filters[rel.field.code_field] = rel.field.code
 
+        def get_prefetch_queryset(self, *args, **kwargs):
+            rel_qs, rel_obj_attr, instance_attr, single, cache_name, is_descriptor = (
+                super().get_prefetch_queryset(*args, **kwargs))
+
+            rel_qs = rel_qs.filter(**{rel.field.code_field: rel.field.code})
+            return rel_qs, rel_obj_attr, instance_attr, single, cache_name, is_descriptor
+
     return RelatedManager
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -51,7 +51,7 @@ def test_coded_generic_relation(author):
     ).exists() is True
     assert Author.objects.filter(
         profile_image__name="wrong_sample.pdf"
-    ).exists() is True
+    ).exists() is False
 
     # test prefetching
     author_prefetched = Author.objects.filter(pk=author.pk).prefetch_related('profile_image').get()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -28,15 +28,32 @@ def test_coded_generic_relation(author):
         code="author_profile_image"
     )
     assert image_qs.exists() is False
+
+    # this image shouldn't appear in querysets as it doesn't contain code
+    _wrong_image = ImageFactory(
+        name="wrong_sample.pdf",
+        content_object=author,
+    )
+
     image = ImageFactory(
         name="sample.pdf",
         content_object=author,
         code="author_profile_image",
     )
+
     assert image_qs.exists() is True
     assert author.profile_image.first() == image
+    assert author.profile_image.count() == 1 # only correct image should appear in profile
 
     # test filtering
     assert Author.objects.filter(
         profile_image__name="sample.pdf"
     ).exists() is True
+    assert Author.objects.filter(
+        profile_image__name="wrong_sample.pdf"
+    ).exists() is True
+
+    # test prefetching
+    author_prefetched = Author.objects.filter(pk=author.pk).prefetch_related('profile_image').get()
+    assert author_prefetched.profile_image.all()[0] == image
+    assert len(author_prefetched.profile_image.all()) == 1


### PR DESCRIPTION
when we use prefetch by coded generic, code doesn't append automatically, so extra objects may appear.

below is the difference between queries, where the first was produced by direct call of generic relation and the second was if from prefetch
```
some_model_instance.photos.all()
4. SELECT ... FROM "photo_photo" WHERE ("photo_photo"."code" = 'photos' AND "photo_photo"."content_type_id" = 20 AND "photo_photo"."object_id" = 1709)
```

```
SomeModel.objects.prefetch_related('photos')
4. SELECT ... FROM "photo_photo" WHERE ("photo_photo"."content_type_id" = 20 AND "photo_photo"."object_id" IN (1710))
```